### PR TITLE
Handle cases when viewing/applying event is deleted

### DIFF
--- a/frontend/app/src/main/java/com/example/gathernow/main_ui/event_application_form/ApplicationFormActivity.java
+++ b/frontend/app/src/main/java/com/example/gathernow/main_ui/event_application_form/ApplicationFormActivity.java
@@ -1,5 +1,6 @@
 package com.example.gathernow.main_ui.event_application_form;
 
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 
 import android.content.Intent;
@@ -13,6 +14,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.example.gathernow.ApplySuccessful;
+import com.example.gathernow.FragHome;
 import com.example.gathernow.R;
 import com.example.gathernow.api.CodeMessageResponse;
 import com.example.gathernow.api.RetrofitClient;
@@ -69,17 +71,32 @@ public class ApplicationFormActivity extends AppCompatActivity {
         hostName = intent.getStringExtra("hostName");
         hostAvatar = intent.getStringExtra("hostAvatar");
 
+        // View model
+        applicationFormViewModel = new ApplicationFormViewModel();
+
         // query event info from database
         getEventInfo();
 
-        // View model
-        applicationFormViewModel = new ApplicationFormViewModel();
         applicationFormViewModel.fetchUserData(userId);
         applicationFormViewModel.getAlertMessage().observe(this, message -> {
             if (message.equals("Application sent successfully")) {
                 Intent intent1 = new Intent(this, ApplySuccessful.class);
                 startActivity(intent1);
                 finish();
+            } else if (message.equals("Event not found")) {
+                // open a dialog to notify the user that the event is not found, then go back to home page
+                AlertDialog.Builder alertBuilder = new AlertDialog.Builder(this);
+                alertBuilder
+                        .setTitle("Error")
+                        .setCancelable(false)
+                        .setMessage("The event you are applying is deleted")
+                        .setPositiveButton("OK", (dialog, which) -> {
+                            // Go back to home page
+                            Intent intent1 = new Intent(this, FragHome.class);
+                            startActivity(intent1);
+                            finish();
+                        });
+                alertBuilder.show();
             } else {
                 Toast.makeText(ApplicationFormActivity.this, message, Toast.LENGTH_SHORT).show();
             }
@@ -105,13 +122,13 @@ public class ApplicationFormActivity extends AppCompatActivity {
         TextView profileName = findViewById(R.id.user_name);
         String displayUserText = "Hosted by " + hostName;
         profileName.setText(displayUserText);
-
         ImageView profileImage = findViewById(R.id.profile_image);
         //Picasso.get().load(hostAvatar).into(profileImage);
 
         int resourceId = R.drawable.ic_user_no_profile;
         ImageLoader imageLoader = new ProxyImageLoader(hostAvatar, resourceId);
         imageLoader.displayImage(profileImage);
+        applicationFormViewModel.fetchEventData(eventId);
 
     }
 

--- a/frontend/app/src/main/java/com/example/gathernow/main_ui/event_application_form/ApplicationFormActivity.java
+++ b/frontend/app/src/main/java/com/example/gathernow/main_ui/event_application_form/ApplicationFormActivity.java
@@ -1,8 +1,5 @@
 package com.example.gathernow.main_ui.event_application_form;
 
-import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.app.AppCompatActivity;
-
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
@@ -13,22 +10,16 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+
 import com.example.gathernow.ApplySuccessful;
 import com.example.gathernow.FragHome;
 import com.example.gathernow.R;
-import com.example.gathernow.api.CodeMessageResponse;
-import com.example.gathernow.api.RetrofitClient;
-import com.example.gathernow.api.ServiceApi;
 import com.example.gathernow.api.models.ApplicationDataModel;
 import com.example.gathernow.api.models.ApplicationDataModelBuilder;
-import com.example.gathernow.api.models.UserDataModel;
 import com.example.gathernow.utils.ImageLoader.ImageLoader;
 import com.example.gathernow.utils.ImageLoader.ProxyImageLoader;
-import com.squareup.picasso.Picasso;
-
-import retrofit2.Call;
-import retrofit2.Callback;
-import retrofit2.Response;
 
 public class ApplicationFormActivity extends AppCompatActivity {
     private int userId;
@@ -89,7 +80,7 @@ public class ApplicationFormActivity extends AppCompatActivity {
                 alertBuilder
                         .setTitle("Error")
                         .setCancelable(false)
-                        .setMessage("The event you are applying is deleted")
+                        .setMessage("The event you are applying is deleted. Please try again later.")
                         .setPositiveButton("OK", (dialog, which) -> {
                             // Go back to home page
                             Intent intent1 = new Intent(this, FragHome.class);
@@ -133,29 +124,50 @@ public class ApplicationFormActivity extends AppCompatActivity {
     }
 
     public void onSendApplicationEvent(View v) {
-        Integer applicant_id = userId;
-        Integer event_id = eventId;
-        Integer host_id = hostId;
-        String applicant_name = username;
+        // Check if event is still available
+        applicationFormViewModel.fetchEventData(eventId);
+        applicationFormViewModel.getAlertMessage().observe(this, message -> {
+            if (message.equals("Event not found")) {
+                // open a dialog to notify the user that the event is not found, then go back to home page
+                AlertDialog.Builder alertBuilder = new AlertDialog.Builder(this);
+                alertBuilder
+                        .setTitle("Error")
+                        .setCancelable(false)
+                        .setMessage("The event you are applying is deleted. Please try again later.")
+                        .setPositiveButton("OK", (dialog, which) -> {
+                            // Go back to home page
+                            Intent intent1 = new Intent(this, FragHome.class);
+                            startActivity(intent1);
+                            finish();
+                        });
+                alertBuilder.show();
+            } else {
+                Integer applicant_id = userId;
+                Integer event_id = eventId;
+                Integer host_id = hostId;
+                String applicant_name = username;
 
-        TextView applicant_contact_input = findViewById(R.id.applicant_contact);
-        String applicant_contact = applicant_contact_input.getText().toString();
+                TextView applicant_contact_input = findViewById(R.id.applicant_contact);
+                String applicant_contact = applicant_contact_input.getText().toString().trim();
 
-        TextView applicant_message_input = findViewById(R.id.applicant_message);
-        String applicant_message = applicant_message_input.getText().toString();
 
-        ApplicationDataModelBuilder applicationBuilder = new ApplicationDataModelBuilder();
-        applicationBuilder.setApplicantContact(applicant_contact)
-                .setApplicantId(applicant_id)
-                .setMessage(applicant_message)
-                .setEventId(event_id)
-                .setHostId(host_id)
-                .setApplicantName(applicant_name)
-                .setApplicantAvatar(userAvatar);
+                TextView applicant_message_input = findViewById(R.id.applicant_message);
+                String applicant_message = applicant_message_input.getText().toString().trim();
 
-        ApplicationDataModel newApplication = applicationBuilder.build();
+                ApplicationDataModelBuilder applicationBuilder = new ApplicationDataModelBuilder();
+                applicationBuilder.setApplicantContact(applicant_contact)
+                        .setApplicantId(applicant_id)
+                        .setMessage(applicant_message)
+                        .setEventId(event_id)
+                        .setHostId(host_id)
+                        .setApplicantName(applicant_name)
+                        .setApplicantAvatar(userAvatar);
+
+                ApplicationDataModel newApplication = applicationBuilder.build();
 //        ApplicationDataModel newApplication = new ApplicationDataModel(applicant_contact, applicant_message, applicant_id, event_id, host_id, applicant_name, userAvatar);
-        applicationFormViewModel.applyEvent(newApplication);
+                applicationFormViewModel.applyEvent(newApplication);
+            }
+        });
 
     }
 

--- a/frontend/app/src/main/java/com/example/gathernow/main_ui/event_application_form/ApplicationFormViewModel.java
+++ b/frontend/app/src/main/java/com/example/gathernow/main_ui/event_application_form/ApplicationFormViewModel.java
@@ -1,5 +1,7 @@
 package com.example.gathernow.main_ui.event_application_form;
 
+import android.util.Log;
+
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
@@ -42,6 +44,24 @@ public class ApplicationFormViewModel extends ViewModel {
             @Override
             public void onError(String message) {
                 alertMessage.setValue(message);
+            }
+        });
+    }
+
+    public void fetchEventData(int eventId) {
+        eventRepository.getEventInfo(eventId, new CallbackInterface() {
+            @Override
+            public <T> void onSuccess(T result) {
+                Log.d("ApplicationFormView debug", "success");
+                EventDataModel res = (EventDataModel) result;
+                if (res == null) {
+                    alertMessage.setValue("Event not found");
+                }
+            }
+
+            @Override
+            public void onError(String message) {
+
             }
         });
     }

--- a/frontend/app/src/main/java/com/example/gathernow/main_ui/event_application_form/ApplicationFormViewModel.java
+++ b/frontend/app/src/main/java/com/example/gathernow/main_ui/event_application_form/ApplicationFormViewModel.java
@@ -34,6 +34,10 @@ public class ApplicationFormViewModel extends ViewModel {
         return applicantData;
     }
 
+    public LiveData<EventDataModel> getEventData() {
+        return eventData;
+    }
+
     public void fetchUserData(int userId) {
         userRemoteRepository.getUserInfo(userId, new CallbackInterface() {
             @Override
@@ -52,8 +56,9 @@ public class ApplicationFormViewModel extends ViewModel {
         eventRepository.getEventInfo(eventId, new CallbackInterface() {
             @Override
             public <T> void onSuccess(T result) {
-                Log.d("ApplicationFormView debug", "success");
+//                Log.d("ApplicationFormView debug", "success");
                 EventDataModel res = (EventDataModel) result;
+                eventData.setValue(res);
                 if (res == null) {
                     alertMessage.setValue("Event not found");
                 }
@@ -61,7 +66,7 @@ public class ApplicationFormViewModel extends ViewModel {
 
             @Override
             public void onError(String message) {
-
+                alertMessage.setValue(message);
             }
         });
     }

--- a/frontend/app/src/main/java/com/example/gathernow/main_ui/event_info/EventInfoActivity.java
+++ b/frontend/app/src/main/java/com/example/gathernow/main_ui/event_info/EventInfoActivity.java
@@ -118,6 +118,20 @@ public class EventInfoActivity extends AppCompatActivity {
                         });
                 alertBuilder.show();
             }
+            else if (message != null && message.equals("Network error")) {
+                // open a dialog to reload the page
+                AlertDialog.Builder alertBuilder = new AlertDialog.Builder(this);
+                alertBuilder
+                        .setTitle("Network error")
+                        .setCancelable(false)
+                        .setMessage("Reload the page?")
+                        .setPositiveButton("OK", (dialog, which) -> {
+                            // reload
+                            finish();
+                            startActivity(getIntent());
+                        });
+                alertBuilder.show();
+            }
             else {
                 Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
             }

--- a/frontend/app/src/main/java/com/example/gathernow/main_ui/event_info/EventInfoActivity.java
+++ b/frontend/app/src/main/java/com/example/gathernow/main_ui/event_info/EventInfoActivity.java
@@ -102,7 +102,26 @@ public class EventInfoActivity extends AppCompatActivity {
         // View Model
         eventInfoViewModel = new EventInfoViewModel(eventRepository);
         // Observe event data changes
-        eventInfoViewModel.getAlertMessage().observe(this, message -> Toast.makeText(this, message, Toast.LENGTH_SHORT).show());
+        eventInfoViewModel.getAlertMessage().observe(this, message -> {
+            if (message != null && (message.equals("Event not found") || message.equals("Application data not found"))) {
+                // open a dialog to notify the user that the event is not found, then go back to home page
+                AlertDialog.Builder alertBuilder = new AlertDialog.Builder(this);
+                alertBuilder
+                        .setTitle("Event not found")
+                        .setCancelable(false)
+                        .setMessage("The event you are looking for is deleted. Do you want to go back?")
+                        .setPositiveButton("OK", (dialog, which) -> {
+                            // Go back to home page
+                            Intent intent1 = new Intent(this, FragHome.class);
+                            startActivity(intent1);
+                            finish();
+                        });
+                alertBuilder.show();
+            }
+            else {
+                Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
+            }
+        });
         eventInfoViewModel.getEventData().observe(this, this::updateEventInfoUI);
         eventInfoViewModel.getHostData().observe(this, this::updateHostInfoUI);
         eventInfoViewModel.getShowRegisterButton().observe(this, showRegisterButton -> {
@@ -365,6 +384,8 @@ public class EventInfoActivity extends AppCompatActivity {
             }
         });
     }
+    );
+    }
 
     private void openNaverMap(double eventLongitude, double eventLatitude) {
         // Create a Uri with the specified latitude and longitude
@@ -441,6 +462,7 @@ public class EventInfoActivity extends AppCompatActivity {
     }
 
     public void onRegisterEvent(View v) {
+        // check whether the current event is staled or not...?
 
         Intent intent = new Intent(v.getContext(), ApplicationFormActivity.class);
 

--- a/frontend/app/src/main/java/com/example/gathernow/main_ui/event_info/EventInfoViewModel.java
+++ b/frontend/app/src/main/java/com/example/gathernow/main_ui/event_info/EventInfoViewModel.java
@@ -106,6 +106,10 @@ public class EventInfoViewModel extends ViewModel {
             public <T> void onSuccess(T result) {
 //                Log.d("EventInfoViewModel", "Load event info successfully");
                 EventDataModel res = (EventDataModel) result;
+                if (res == null) {
+                    alertMessage.postValue("Event not found");
+                    return;
+                }
                 eventData.postValue(res);
                 loadHostInfo(res.getHostId());
                 setButtonVisibility(userId, res.getHostId(), res.getEventId());

--- a/frontend/app/src/test/java/com/example/gathernow/main_ui/event_application_form/ApplicationFormViewModelTest.java
+++ b/frontend/app/src/test/java/com/example/gathernow/main_ui/event_application_form/ApplicationFormViewModelTest.java
@@ -6,7 +6,10 @@ import androidx.lifecycle.Observer;
 
 import com.example.gathernow.api.ServiceApi;
 import com.example.gathernow.api.models.ApplicationDataModel;
+import com.example.gathernow.api.models.EventDataModel;
+import com.example.gathernow.api.models.EventDataModelBuilder;
 import com.example.gathernow.api.models.UserDataModel;
+import com.example.gathernow.api.models.UserDataModelBuilder;
 import com.example.gathernow.main_ui.CallbackInterface;
 import com.example.gathernow.main_ui.EventRepository;
 import com.example.gathernow.main_ui.UserRemoteRepository;
@@ -45,6 +48,8 @@ public class ApplicationFormViewModelTest extends TestCase {
 
     @Mock
     private Observer<String> mockAlertMessageObserver;
+    @Mock
+    private Observer<EventDataModel> mockEventDataObserver;
 
     @Captor
     private ArgumentCaptor<CallbackInterface> callbackCaptor;
@@ -60,12 +65,69 @@ public class ApplicationFormViewModelTest extends TestCase {
         viewModel.userRemoteRepository = mockUserRemoteRepository;
         viewModel.getApplicantData().observeForever(mockUserDataObserver);
         viewModel.getAlertMessage().observeForever(mockAlertMessageObserver);
+        viewModel.getEventData().observeForever(mockEventDataObserver);
     }
     private UserDataModel mockUserDataModels() {
-        UserDataModel userDataModels = new UserDataModel("Kiwi", "kiwi@gmail.com", 2, "2023-11-27 16:22:41.734874", "avatar_image/picture10.png");
-        return userDataModels;
+        return new UserDataModelBuilder()
+                .setName("Kiwi")
+                .setEmail("kiwi@gmail.com")
+                .setUserId(2)
+                .setAvatar("avatar_image/picture10.png")
+                .setCreatedAt("2023-11-27 16:22:41.734874")
+                .build();
     }
 
+    private EventDataModel mockEventDataModels() {
+        return new EventDataModelBuilder()
+                .setEventId(0)
+                .setEventType("Leisure")
+                .setEventTitle("Test Event")
+                .setEventMaxParticipants(10)
+                .setEventJoined(0)
+                .setEventDate("2024-04-20")
+                .setEventTime("12:00:00")
+                .setEventDuration("2 hours")
+                .setEventLanguage("English")
+                .setEventPrice(0)
+                .setEventLocation("Test Location")
+                .setEventLongitude(0.0)
+                .setEventLatitude(0.0)
+                .setEventDescription("Test description")
+                .setHostId(0)
+                .setHostId(0)
+                .setEventRegisterDate("2024-04-20")
+                .setEventRegisterTime("12:00:00")
+                .setEventImages("Test Image")
+                .build();
+    }
+
+    @Test
+    public void fetchEventData_success() {
+        int eventId = 0;
+        EventDataModel eventDataModel = mockEventDataModels();
+
+        viewModel.fetchEventData(eventId);
+
+        Mockito.verify(mockEventRepository).getEventInfo(Mockito.eq(eventId), callbackCaptor.capture());
+        callbackCaptor.getValue().onSuccess(eventDataModel);
+
+        Mockito.verify(mockEventDataObserver).onChanged(Mockito.eq(eventDataModel));
+        Mockito.verifyNoMoreInteractions(mockAlertMessageObserver);
+    }
+
+    @Test
+    public void fetchEventData_null() {
+        int eventId = 0;
+        String errorMessage = "Event not found";
+
+        viewModel.fetchEventData(eventId);
+
+        Mockito.verify(mockEventRepository).getEventInfo(Mockito.eq(eventId), callbackCaptor.capture());
+        callbackCaptor.getValue().onSuccess(null);
+
+        Mockito.verify(mockAlertMessageObserver).onChanged(Mockito.eq(errorMessage));
+        Mockito.verify(mockEventDataObserver).onChanged(Mockito.eq(null));
+    }
 
     @Test
     public void fetchUserData_success() {
@@ -109,7 +171,7 @@ public class ApplicationFormViewModelTest extends TestCase {
 
 
     @Test
-    public void applyEvent_validInput_success() {
+    public void applyEvent_validInput_eventAvailable_success() {
         ApplicationDataModel applicationDataModel = mockApplicationDataModelsList().get(0);
 
         viewModel.applyEvent(applicationDataModel);


### PR DESCRIPTION
### PR Title: Handle cases when viewing/applying event is deleted
#### Related Issue(s):
When a user clicks on a staled event, there is no alert telling them the event is unavailable. Similarly, when they register for an event, there is a chance that they are applying to an event that was deleted recently. 
#### PR Description:
- Added a logic to check whether the event is unavailable in EventInfoActivity
- Added a logic to check whether the applying event is unavailable in ApplicationFormActivity
- Added a dialog allowing a user to reload the page when a network error occurs (currently only implemented in EventInfoActivity)
- Added unit tests in ApplicationFormViewModel
##### Changes Included:
- [x] Added new feature(s)
- [x] Fixed identified bug(s)
- [ ] Updated relevant documentation
##### Screenshots (if UI changes were made):
Attach screenshots or GIFs of any visual changes. (Only for frontend-related changes)
##### Notes for Reviewer:
Any specific instructions or points to be considered by the reviewer.

---
#### Reviewer Checklist:
- [x] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [x] All existing tests pass.
- [x] Manual testing has been performed to ensure the PR works as expected.
- [x] Code review comments have been addressed or clarified.

---
#### Additional Comments:
Add any other comments or information that might be useful for the review process.